### PR TITLE
Remove unneeded encodeURIComponent in generator

### DIFF
--- a/generator/generator.ts
+++ b/generator/generator.ts
@@ -454,9 +454,9 @@ export type { CredentialsClient };`;
         this.#w.block(() => {
           this.#w.write(`url.searchParams.append(`);
           this.#w.quote(name);
-          this.#w.write(`, encodeURIComponent(String(opts`);
+          this.#w.write(`, String(opts`);
           this.#writeIndex(name);
-          this.#w.write(`)));`);
+          this.#w.write(`));`);
         });
       }
       // create request body


### PR DESCRIPTION
- This is not needed because URLSearchParams will already correctly encode all of its parameters, and a second encodeURIComponent will double-encode its strings.